### PR TITLE
Forbids access to the .git directory via .htaccess.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -16,8 +16,8 @@ RewriteEngine on
 #
 # RewriteBase /mysite
 
-# forbid access to the .git directory
-RewriteRule ^(\.git/) - [F,L,NC]
+# forbid access to all .git directories
+RewriteRule \.git - [F,L,NC]
 
 # block text files in the content folder from being accessed directly
 RewriteRule ^content/(.*)\.(txt|md|mdown)$ error [R=301,L]

--- a/.htaccess
+++ b/.htaccess
@@ -16,6 +16,9 @@ RewriteEngine on
 #
 # RewriteBase /mysite
 
+# forbid access to the .git directory
+RewriteRule ^(\.git/) - [F,L,NC]
+
 # block text files in the content folder from being accessed directly
 RewriteRule ^content/(.*)\.(txt|md|mdown)$ error [R=301,L]
 


### PR DESCRIPTION
Since I believe most developers deploy their Kirby websites using Git, it would be a good idea to forbid access to the `.git` directory containing the entire history of the site and possibly sensitive data.

This also affects the [plainkit](https://github.com/getkirby/plainkit).
