### PR TITLE
Removed typo

### DIFF
--- a/content/home/home.txt
+++ b/content/home/home.txt
@@ -14,7 +14,7 @@ Text:
 - Check out the (link: http://getkirby.com/docs text: docs) and start building your own site
 - Follow (twitter: @getkirby) on Twitter for updates
 - Visit the (link: http://forum.getkirby.com text: forum) to connect with other Kirby users
-- Sign up to (link: (link: https://getkirby.com/#kosmos text: Kirby Kosmos), our monthly newsletter
+- Sign up to (link: https://getkirby.com/#kosmos text: Kirby Kosmos), our monthly newsletter
 - (link: http://getkirby.com/support text: Get in contact) if you need support.
 
 **Have fun with Kirby!**


### PR DESCRIPTION
Removed a simple typo - there were 2 "(link:" opening tags.