### PR TITLE
Block files and folders beginning with dot

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,6 +21,10 @@ RewriteEngine on
 #
 # RewriteBase /
 
+# Block files and folders beginning with dot, such as .git
+# except for .well-known folder, which is used for Let's Encrypt and security.txt
+RewriteRule "(^|/)\.(?!well-known\/)" - [F]
+
 # block text files in the content folder from being accessed directly
 RewriteRule ^content/(.*)\.(txt|md|mdown)$ index.php [L]
 


### PR DESCRIPTION
Block files and folders beginning with dot, such as .git except for .well-known folder, which is used for Let's Encrypt and security.txt

* This rule prevents the use of tools like https://github.com/internetwache/GitTools from getting the Kirby source of websites deployed with .git repositories. 
* Also prevents accessing some folders and files beginning with dot created by various IDEs and workflows.